### PR TITLE
Upgrade to new ingress controller 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Container bundled with utilities for network testing
 
-[![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=for-the-badge&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2modernisation-platform-cp-network-test)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#modernisation-platform-cp-network-test "Link to report")
+[![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=for-the-badge&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fmodernisation-platform-cp-network-test)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#modernisation-platform-cp-network-test "Link to report")
 
 ## Run the Node.JS application locally
 

--- a/kubectl_deploy/ingress.yaml
+++ b/kubectl_deploy/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nettest-ingress
@@ -7,6 +7,7 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: nettest-ingress-nettest-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
+  ingressClassName: default
   tls:
   - hosts:
     - nettest.apps.live.cloud-platform.service.justice.gov.uk
@@ -15,6 +16,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: nettest-service
-          servicePort: 3000
+          service:
+            name: nettest-service
+            port:
+              number: 3000

--- a/kubectl_deploy/ingress.yaml
+++ b/kubectl_deploy/ingress.yaml
@@ -9,16 +9,16 @@ metadata:
 spec:
   ingressClassName: default
   tls:
-  - hosts:
-    - nettest.apps.live.cloud-platform.service.justice.gov.uk
+    - hosts:
+        - nettest.apps.live.cloud-platform.service.justice.gov.uk
   rules:
-  - host: nettest.apps.live.cloud-platform.service.justice.gov.uk
-    http:
-      paths:
-      - path: /
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: nettest-service
-            port:
-              number: 3000
+    - host: nettest.apps.live.cloud-platform.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nettest-service
+                port:
+                  number: 3000


### PR DESCRIPTION
Following this guidance https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html#switch-ingress-to-the-new-nginx-ingress-controller-v1-2

to switch to the new controller.

This has been manually redeployed.